### PR TITLE
Doc improvements // Deoplyment hang fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,436 +26,56 @@ See [Example Playbooks](#example-playbooks) below.
 
 <!-- BEGIN ANSIBLE ROLE VARIABLES -->
 
-### `dawarich_data_path`
-
-| Type | Default         | Required |
-| ---- | --------------- | -------- |
-| path | `/opt/dawarich` | ❌       |
-
-Dawarich data path on the host.
-
-### `dawarich_docker_network_name`
-
-| Type   | Default    | Required |
-| ------ | ---------- | -------- |
-| string | `dawarich` | ❌       |
-
-Name of the Docker network to connect the Dawarich containers to.
-
-### `dawarich_version`
-
-| Type   | Default  | Required |
-| ------ | -------- | -------- |
-| string | `latest` | ❌       |
-
-Dawarich application Docker image version (tag).
-
-### `dawarich_app_hosts`
-
-| Type   | Default | Required |
-| ------ | ------- | -------- |
-| string | None    | ❌       |
-
-Host of the Dawarich application (e.g. dawarich.example.com).
-
-> [!NOTE]
-> Regardless of the user-specified value, `localhost,::1,127.0.0.1` will always be added to Dawarich's `APPLICATION_HOSTS`.  
-> Example: If you set the value as `dawarich.example.com`, it will be set to `dawarich.example.com,localhost,::1,127.0.0.1`  
-> If left default (`None`), Dawarich's `APPLICATION_HOSTS` will be `localhost,::1,127.0.0.1`.
-
-### `dawarich_app_protocol`
-
-| Type   | Default | Required |
-| ------ | ------- | -------- |
-| string | `http`  | ❌       |
-
-Protocol for the Dawarich application.
-
-Set to `https` if accessing Dawarich through a SSL-terminating reverse proxy.
-
-Must be one of: `http`, `https`.
-
-### `dawarich_port`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| int  | `3000`  | ❌       |
-
-Dawarich application port.
-
-### `dawarich_rails_env`
-
-| Type   | Default       | Required |
-| ------ | ------------- | -------- |
-| string | `development` | ❌       |
-
-Rails environment for the Dawarich application.
-
-This should ideally be `production`, but some bugs have been observed in production mode that are not present in development mode.
-
-### `dawarich_timezone`
-
-| Type   | Default   | Required |
-| ------ | --------- | -------- |
-| string | `Etc/UTC` | ❌       |
-
-Timezone for the Dawarich application.
-
-See <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List>
-
-### `dawarich_min_minutes_spent_in_city`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| int  | `60`    | ❌       |
-
-Minimum minutes spent in a city to be counted.
-
-### `dawarich_background_processing_concurrency`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| int  | `10`    | ❌       |
-
-Number of background processing workers per Sidekiq worker.
-
-### `dawarich_store_geodata`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| bool | `true`  | ❌       |
-
-Enable storing of geodata in the Dawarich database.
-
-### `dawarich_rails_max_threads`
-
-| Type | Default                                                               | Required |
-| ---- | --------------------------------------------------------------------- | -------- |
-| int  | `dawarich_workers_count * dawarich_background_processing_concurrency` | ❌       |
-
-Connection pool size for the Dawarich database.
-
-> [!TIP]
-> The default value, if undefined, is the number of workers ([`dawarich_workers_count`](#dawarich_workers_count)) multiplied by the background processing concurrecy ([`dawarich_background_processing_concurrency`](#dawarich_background_processing_concurrency)).  
-> For example, with 1 worker (default) and 10 background workers (default), this would be 10.
-
-### `dawarich_encryption_secret_key`
-
-| Type   | Default | Required |
-| ------ | ------- | -------- |
-| string | None    | ✅       |
-
-The Dawarich encryption salt/secret key (Rails' `secret_key_base`).
-
-### `dawarich_workers_count`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| int  | `1`     | ❌       |
-
-Number of Sidekiq workers to deploy.
-
-### `dawarich_reverse_geocoding_enabled`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| bool | `true`  | ❌       |
-
-Enable reverse geocoding.
-
-### `dawarich_photon_api_host`
-
-| Type   | Default                               | Required |
-| ------ | ------------------------------------- | -------- |
-| string | `''` or `dawarich-photon` (see below) | ❌       |
-
-API host for the Photon reverse geocoding service.
-
-If [`dawarich_deploy_photon`](#dawarich_deploy_photon) is `false`, this will default to an empty string.
-
-Otherwise, if [`dawarich_deploy_photon`](#dawarich_deploy_photon) is `true`, this will default to `dawarich-photon` (the name of the Photon container).
-
-You will only need to change this if you wish to use a different Photon instance, whether self-hosted or public.
-
-### `dawarich_photon_api_use_https`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| bool | `true`  | ❌       |
-
-Use HTTPS for requests to the Photon API.
-
-### `dawarich_enable_prometheus_metrics`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| bool | `false` | ❌       |
-
-Enable Prometheus metrics endpoint.
-
-Once enabled, Prometheus metrics will be available at `localhost:<dawarich_prometheus_port>/metrics`
-
-### `dawarich_prometheus_port`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| int  | `9394`  | ❌       |
-
-Prometheus metrics port for Dawarich.
-
-### `dawarich_shared_extra_env`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| dict | `{}`    | ❌       |
-
-Additional environment variables to apply to both the Dawarich application and the Sidekiq worker(s) containers.
-
-### `dawarich_app_extra_env`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| dict | `{}`    | ❌       |
-
-Additional environment variables for the Dawarich application container.
-
-### `dawarich_sidekiq_extra_env`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| dict | `{}`    | ❌       |
-
-Additional environment variables for the Dawarich Sidekiq worker container(s).
-
-### `dawarich_log_max_size`
-
-| Type   | Default | Required |
-| ------ | ------- | -------- |
-| string | `100m`  | ❌       |
-
-Maximum size of Docker log files before rotation.
-
-### `dawarich_log_max_file`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| int  | `5`     | ❌       |
-
-Maximum number of Docker log files to keep.
-
-### `dawarich_app_cpu_limit`
-
-| Type   | Default | Required |
-| ------ | ------- | -------- |
-| string | `0.50`  | ❌       |
-
-CPU limit for the Dawarich application container (e.g., `0.50` for 50% of one core).
-
-Set to `0` to disable CPU limit.
-
-### `dawarich_app_memory_limit`
-
-| Type   | Default | Required |
-| ------ | ------- | -------- |
-| string | `4G`    | ❌       |
-
-Memory limit for the Dawarich application container.
-
-Set to `0` to disable memory limit.
-
-### `dawarich_sidekiq_cpu_limit`
-
-| Type   | Default | Required |
-| ------ | ------- | -------- |
-| string | `0.50`  | ❌       |
-
-CPU limit for each Dawarich Sidekiq worker container (e.g., `0.50` for 50% of one core).
-
-Set to `0` to disable CPU limit.
-
-### `dawarich_sidekiq_memory_limit`
-
-| Type   | Default | Required |
-| ------ | ------- | -------- |
-| string | `4G`    | ❌       |
-
-Memory limit for each Dawarich Sidekiq worker container.
-
-Set to `0` to disable memory limit.
-
-### `dawarich_deploy_postgis`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| bool | `true`  | ❌       |
-
-Deploy a PostGIS instance for Dawarich.
-
-Set to `false` if using an external PostGIS instance.
-
-### `dawarich_postgis_version`
-
-| Type   | Default         | Required |
-| ------ | --------------- | -------- |
-| string | `17-3.5-alpine` | ❌       |
-
-PostGIS Docker image version for Dawarich.
-
-### `dawarich_postgis_host`
-
-| Type   | Default       | Required |
-| ------ | ------------- | -------- |
-| string | `dawarich-db` | ❌       |
-
-PostGIS host for Dawarich.
-
-### `dawarich_postgis_port`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| int  | `5432`  | ❌       |
-
-PostGIS port for Dawarich.
-
-### `dawarich_postgis_db_name`
-
-| Type   | Default    | Required |
-| ------ | ---------- | -------- |
-| string | `dawarich` | ❌       |
-
-PostGIS database name for Dawarich.
-
-### `dawarich_postgis_username`
-
-| Type   | Default    | Required |
-| ------ | ---------- | -------- |
-| string | `dawarich` | ❌       |
-
-PostGIS username for Dawarich.
-
-### `dawarich_postgis_password`
-
-| Type   | Default | Required |
-| ------ | ------- | -------- |
-| string | None    | ✅       |
-
-PostGIS password for Dawarich.
-
-### `dawarich_postgis_use_custom_config`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| bool | `false` | ❌       |
-
-Set to `true` if you want to use a custom config file.
-
-### `dawarich_postgis_conf_file`
-
-| Type   | Default | Required |
-| ------ | ------- | -------- |
-| string |         | ❌       |
-
-Path to the PostgreSQL config file on the Ansible controller.
-
-If left default (empty) and `dawarich_postgis_use_custom_config` is `true`, the example config will be downloaded from the Dawarich repository at <https://github.com/Freika/dawarich/blob/master/postgisql.conf.example.>
-
-> [!NOTE]
-> This is ignored unless `dawarich_postgis_use_custom_config` is `true`.
-
-### `dawarich_deploy_redis`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| bool | `true`  | ❌       |
-
-Deploy a Redis instance for Dawarich.
-
-Set to `false` if using an external Redis instance.
-
-### `dawarich_redis_version`
-
-| Type   | Default      | Required |
-| ------ | ------------ | -------- |
-| string | `7.4-alpine` | ❌       |
-
-Redis Docker image version for Dawarich.
-
-### `dawarich_redis_host`
-
-| Type   | Default          | Required |
-| ------ | ---------------- | -------- |
-| string | `dawarich-redis` | ❌       |
-
-Redis host for Dawarich.
-
-### `dawarich_redis_port`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| int  | `6379`  | ❌       |
-
-Redis port for Dawarich.
-
-### `dawarich_deploy_photon`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| bool | `false` | ❌       |
-
-Deploy a Photon instance for reverse geocoding.
-
-> [!NOTE]
-> Assuming you are not specifying `dawarich_photon_region` to limit the downloaded dataset to a single region, this requires well over 120GB of disk space and a significant amount of RAM (16GB is recommended but not always required).
-
-### `dawarich_photon_version`
-
-| Type   | Default  | Required |
-| ------ | -------- | -------- |
-| string | `latest` | ❌       |
-
-Photon Docker image version for reverse geocoding.
-
-### `dawarich_photon_data_path`
-
-| Type | Default                | Required |
-| ---- | ---------------------- | -------- |
-| path | `/opt/dawarich/photon` | ❌       |
-
-Photon data path on the host.
-
-### `dawarich_photon_port`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| int  | `2322`  | ❌       |
-
-Photon application port.
-
-### `dawarich_photon_region`
-
-| Type   | Default | Required |
-| ------ | ------- | -------- |
-| string |         | ❌       |
-
-Photon reverse geocoding region.
-
-You can see available regions at <https://github.com/rtuszik/photon-docker/blob/main/README.md#available-regions>
-
-### `dawarich_photon_extra_env`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| dict | `{}`    | ❌       |
-
-Additional environment variables for the Photon container.
-
-### `dawarich_prune_docker_images`
-
-| Type | Default | Required |
-| ---- | ------- | -------- |
-| bool | `true`  | ❌       |
-
-Prune *all* Docker images after deployment if any container has changed.
+| Variable | Type | Default | Required | Description |
+|----------|------|---------|----------|-------------|
+| `dawarich_data_path` | path | `/opt/dawarich` | ❌ | Dawarich data path on the host. |
+| `dawarich_docker_network_name` | string | `dawarich` | ❌ | Name of the Docker network to connect the Dawarich containers to. |
+| `dawarich_version` | string | `latest` | ❌ | Dawarich application Docker image version (tag). |
+| `dawarich_app_hosts` | string | None | ❌ | Host of the Dawarich application (e.g. dawarich.example.com).<br><br>**Note:** Regardless of the user-specified value, `localhost,::1,127.0.0.1` will always be added to Dawarich's `APPLICATION_HOSTS`. Example: If you set the value as `dawarich.example.com`, it will be set to `dawarich.example.com,localhost,::1,127.0.0.1`. If left default (`None`), Dawarich's `APPLICATION_HOSTS` will be `localhost,::1,127.0.0.1`. |
+| `dawarich_app_protocol` | string | `http` | ❌ | Protocol for the Dawarich application. Set to `https` if accessing Dawarich through a SSL-terminating reverse proxy. Must be one of: `http`, `https`. |
+| `dawarich_port` | int | `3000` | ❌ | Dawarich application port. |
+| `dawarich_rails_env` | string | `development` | ❌ | Rails environment for the Dawarich application. This should ideally be `production`, but some bugs have been observed in production mode that are not present in development mode. |
+| `dawarich_timezone` | string | `Etc/UTC` | ❌ | Timezone for the Dawarich application. See <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List>. |
+| `dawarich_min_minutes_spent_in_city` | int | `60` | ❌ | Minimum minutes spent in a city to be counted. |
+| `dawarich_background_processing_concurrency` | int | `10` | ❌ | Number of background processing workers per Sidekiq worker. |
+| `dawarich_store_geodata` | bool | `true` | ❌ | Enable storing of geodata in the Dawarich database. |
+| `dawarich_rails_max_threads` | int | `dawarich_workers_count * dawarich_background_processing_concurrency` | ❌ | Connection pool size for the Dawarich database.<br><br>**Tip:** The default value, if undefined, is the number of workers multiplied by the background processing concurrency. For example, with 1 worker (default) and 10 background workers (default), this would be 10. |
+| `dawarich_encryption_secret_key` | string | None | ✅ | The Dawarich encryption salt/secret key (Rails' `secret_key_base`). |
+| `dawarich_workers_count` | int | `1` | ❌ | Number of Sidekiq workers to deploy. |
+| `dawarich_reverse_geocoding_enabled` | bool | `true` | ❌ | Enable reverse geocoding. |
+| `dawarich_photon_api_host` | string | `''` or `dawarich-photon` (see below) | ❌ | API host for the Photon reverse geocoding service. If `dawarich_deploy_photon` is `false`, this will default to an empty string. Otherwise, if `dawarich_deploy_photon` is `true`, this will default to `dawarich-photon` (the name of the Photon container). You will only need to change this if you wish to use a different Photon instance, whether self-hosted or public. |
+| `dawarich_photon_api_use_https` | bool | `true` | ❌ | Use HTTPS for requests to the Photon API. |
+| `dawarich_enable_prometheus_metrics` | bool | `false` | ❌ | Enable Prometheus metrics endpoint. Once enabled, Prometheus metrics will be available at `localhost:<dawarich_prometheus_port>/metrics`. |
+| `dawarich_prometheus_port` | int | `9394` | ❌ | Prometheus metrics port for Dawarich. |
+| `dawarich_shared_extra_env` | dict | `{}` | ❌ | Additional environment variables to apply to both the Dawarich application and the Sidekiq worker(s) containers. |
+| `dawarich_app_extra_env` | dict | `{}` | ❌ | Additional environment variables for the Dawarich application container. |
+| `dawarich_sidekiq_extra_env` | dict | `{}` | ❌ | Additional environment variables for the Dawarich Sidekiq worker container(s). |
+| `dawarich_log_max_size` | string | `100m` | ❌ | Maximum size of Docker log files before rotation. |
+| `dawarich_log_max_file` | int | `5` | ❌ | Maximum number of Docker log files to keep. |
+| `dawarich_app_cpu_limit` | string | `0.50` | ❌ | CPU limit for the Dawarich application container (e.g., `0.50` for 50% of one core). Set to `0` to disable CPU limit. |
+| `dawarich_app_memory_limit` | string | `4G` | ❌ | Memory limit for the Dawarich application container. Set to `0` to disable memory limit. |
+| `dawarich_sidekiq_cpu_limit` | string | `0.50` | ❌ | CPU limit for each Dawarich Sidekiq worker container (e.g., `0.50` for 50% of one core). Set to `0` to disable CPU limit. |
+| `dawarich_sidekiq_memory_limit` | string | `4G` | ❌ | Memory limit for each Dawarich Sidekiq worker container. Set to `0` to disable memory limit. |
+| `dawarich_deploy_postgis` | bool | `true` | ❌ | Deploy a PostGIS instance for Dawarich. Set to `false` if using an external PostGIS instance. |
+| `dawarich_postgis_version` | string | `17-3.5-alpine` | ❌ | PostGIS Docker image version for Dawarich. |
+| `dawarich_postgis_host` | string | `dawarich-db` | ❌ | PostGIS host for Dawarich. |
+| `dawarich_postgis_port` | int | `5432` | ❌ | PostGIS port for Dawarich. |
+| `dawarich_postgis_db_name` | string | `dawarich` | ❌ | PostGIS database name for Dawarich. |
+| `dawarich_postgis_username` | string | `dawarich` | ❌ | PostGIS username for Dawarich. |
+| `dawarich_postgis_password` | string | None | ✅ | PostGIS password for Dawarich. |
+| `dawarich_postgis_use_custom_config` | bool | `false` | ❌ | Set to `true` if you want to use a custom config file. |
+| `dawarich_postgis_conf_file` | string |  | ❌ | Path to the PostgreSQL config file on the Ansible controller. If left default (empty) and `dawarich_postgis_use_custom_config` is `true`, the example config will be downloaded from the Dawarich repository at <https://github.com/Freika/dawarich/blob/master/postgisql.conf.example>.<br><br>**Note:** This is ignored unless `dawarich_postgis_use_custom_config` is `true`. |
+| `dawarich_deploy_redis` | bool | `true` | ❌ | Deploy a Redis instance for Dawarich. Set to `false` if using an external Redis instance. |
+| `dawarich_redis_version` | string | `7.4-alpine` | ❌ | Redis Docker image version for Dawarich. |
+| `dawarich_redis_host` | string | `dawarich-redis` | ❌ | Redis host for Dawarich. |
+| `dawarich_redis_port` | int | `6379` | ❌ | Redis port for Dawarich. |
+| `dawarich_deploy_photon` | bool | `false` | ❌ | Deploy a Photon instance for reverse geocoding.<br><br>**Note:** Assuming you are not specifying `dawarich_photon_region` to limit the downloaded dataset to a single region, this requires well over 120GB of disk space and a significant amount of RAM (16GB is recommended but not always required). |
+| `dawarich_photon_version` | string | `latest` | ❌ | Photon Docker image version for reverse geocoding. |
+| `dawarich_photon_data_path` | path | `/opt/dawarich/photon` | ❌ | Photon data path on the host. |
+| `dawarich_photon_port` | int | `2322` | ❌ | Photon application port. |
+| `dawarich_photon_region` | string |  | ❌ | Photon reverse geocoding region. You can see available regions at <https://github.com/rtuszik/photon-docker/blob/main/README.md#available-regions>. |
+| `dawarich_photon_extra_env` | dict | `{}` | ❌ | Additional environment variables for the Photon container. |
+| `dawarich_prune_docker_images` | bool | `true` | ❌ | Prune *all* Docker images after deployment if any container has changed. |
 
 <!-- END ANSIBLE ROLE VARIABLES -->
 

--- a/README.md
+++ b/README.md
@@ -26,56 +26,176 @@ See [Example Playbooks](#example-playbooks) below.
 
 <!-- BEGIN ANSIBLE ROLE VARIABLES -->
 
-| Variable | Type | Default | Required | Description |
-|----------|------|---------|----------|-------------|
-| `dawarich_data_path` | path | `/opt/dawarich` | ❌ | Dawarich data path on the host. |
-| `dawarich_docker_network_name` | string | `dawarich` | ❌ | Name of the Docker network to connect the Dawarich containers to. |
-| `dawarich_version` | string | `latest` | ❌ | Dawarich application Docker image version (tag). |
-| `dawarich_app_hosts` | string | None | ❌ | Host of the Dawarich application (e.g. dawarich.example.com).<br><br>**Note:** Regardless of the user-specified value, `localhost,::1,127.0.0.1` will always be added to Dawarich's `APPLICATION_HOSTS`. Example: If you set the value as `dawarich.example.com`, it will be set to `dawarich.example.com,localhost,::1,127.0.0.1`. If left default (`None`), Dawarich's `APPLICATION_HOSTS` will be `localhost,::1,127.0.0.1`. |
-| `dawarich_app_protocol` | string | `http` | ❌ | Protocol for the Dawarich application. Set to `https` if accessing Dawarich through a SSL-terminating reverse proxy. Must be one of: `http`, `https`. |
-| `dawarich_port` | int | `3000` | ❌ | Dawarich application port. |
-| `dawarich_rails_env` | string | `development` | ❌ | Rails environment for the Dawarich application. This should ideally be `production`, but some bugs have been observed in production mode that are not present in development mode. |
-| `dawarich_timezone` | string | `Etc/UTC` | ❌ | Timezone for the Dawarich application. See <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List>. |
-| `dawarich_min_minutes_spent_in_city` | int | `60` | ❌ | Minimum minutes spent in a city to be counted. |
-| `dawarich_background_processing_concurrency` | int | `10` | ❌ | Number of background processing workers per Sidekiq worker. |
-| `dawarich_store_geodata` | bool | `true` | ❌ | Enable storing of geodata in the Dawarich database. |
-| `dawarich_rails_max_threads` | int | `dawarich_workers_count * dawarich_background_processing_concurrency` | ❌ | Connection pool size for the Dawarich database.<br><br>**Tip:** The default value, if undefined, is the number of workers multiplied by the background processing concurrency. For example, with 1 worker (default) and 10 background workers (default), this would be 10. |
-| `dawarich_encryption_secret_key` | string | None | ✅ | The Dawarich encryption salt/secret key (Rails' `secret_key_base`). |
-| `dawarich_workers_count` | int | `1` | ❌ | Number of Sidekiq workers to deploy. |
-| `dawarich_reverse_geocoding_enabled` | bool | `true` | ❌ | Enable reverse geocoding. |
-| `dawarich_photon_api_host` | string | `''` or `dawarich-photon` (see below) | ❌ | API host for the Photon reverse geocoding service. If `dawarich_deploy_photon` is `false`, this will default to an empty string. Otherwise, if `dawarich_deploy_photon` is `true`, this will default to `dawarich-photon` (the name of the Photon container). You will only need to change this if you wish to use a different Photon instance, whether self-hosted or public. |
-| `dawarich_photon_api_use_https` | bool | `true` | ❌ | Use HTTPS for requests to the Photon API. |
-| `dawarich_enable_prometheus_metrics` | bool | `false` | ❌ | Enable Prometheus metrics endpoint. Once enabled, Prometheus metrics will be available at `localhost:<dawarich_prometheus_port>/metrics`. |
-| `dawarich_prometheus_port` | int | `9394` | ❌ | Prometheus metrics port for Dawarich. |
-| `dawarich_shared_extra_env` | dict | `{}` | ❌ | Additional environment variables to apply to both the Dawarich application and the Sidekiq worker(s) containers. |
-| `dawarich_app_extra_env` | dict | `{}` | ❌ | Additional environment variables for the Dawarich application container. |
-| `dawarich_sidekiq_extra_env` | dict | `{}` | ❌ | Additional environment variables for the Dawarich Sidekiq worker container(s). |
-| `dawarich_log_max_size` | string | `100m` | ❌ | Maximum size of Docker log files before rotation. |
-| `dawarich_log_max_file` | int | `5` | ❌ | Maximum number of Docker log files to keep. |
-| `dawarich_app_cpu_limit` | string | `0.50` | ❌ | CPU limit for the Dawarich application container (e.g., `0.50` for 50% of one core). Set to `0` to disable CPU limit. |
-| `dawarich_app_memory_limit` | string | `4G` | ❌ | Memory limit for the Dawarich application container. Set to `0` to disable memory limit. |
-| `dawarich_sidekiq_cpu_limit` | string | `0.50` | ❌ | CPU limit for each Dawarich Sidekiq worker container (e.g., `0.50` for 50% of one core). Set to `0` to disable CPU limit. |
-| `dawarich_sidekiq_memory_limit` | string | `4G` | ❌ | Memory limit for each Dawarich Sidekiq worker container. Set to `0` to disable memory limit. |
-| `dawarich_deploy_postgis` | bool | `true` | ❌ | Deploy a PostGIS instance for Dawarich. Set to `false` if using an external PostGIS instance. |
-| `dawarich_postgis_version` | string | `17-3.5-alpine` | ❌ | PostGIS Docker image version for Dawarich. |
-| `dawarich_postgis_host` | string | `dawarich-db` | ❌ | PostGIS host for Dawarich. |
-| `dawarich_postgis_port` | int | `5432` | ❌ | PostGIS port for Dawarich. |
-| `dawarich_postgis_db_name` | string | `dawarich` | ❌ | PostGIS database name for Dawarich. |
-| `dawarich_postgis_username` | string | `dawarich` | ❌ | PostGIS username for Dawarich. |
-| `dawarich_postgis_password` | string | None | ✅ | PostGIS password for Dawarich. |
-| `dawarich_postgis_use_custom_config` | bool | `false` | ❌ | Set to `true` if you want to use a custom config file. |
-| `dawarich_postgis_conf_file` | string |  | ❌ | Path to the PostgreSQL config file on the Ansible controller. If left default (empty) and `dawarich_postgis_use_custom_config` is `true`, the example config will be downloaded from the Dawarich repository at <https://github.com/Freika/dawarich/blob/master/postgisql.conf.example>.<br><br>**Note:** This is ignored unless `dawarich_postgis_use_custom_config` is `true`. |
-| `dawarich_deploy_redis` | bool | `true` | ❌ | Deploy a Redis instance for Dawarich. Set to `false` if using an external Redis instance. |
-| `dawarich_redis_version` | string | `7.4-alpine` | ❌ | Redis Docker image version for Dawarich. |
-| `dawarich_redis_host` | string | `dawarich-redis` | ❌ | Redis host for Dawarich. |
-| `dawarich_redis_port` | int | `6379` | ❌ | Redis port for Dawarich. |
-| `dawarich_deploy_photon` | bool | `false` | ❌ | Deploy a Photon instance for reverse geocoding.<br><br>**Note:** Assuming you are not specifying `dawarich_photon_region` to limit the downloaded dataset to a single region, this requires well over 120GB of disk space and a significant amount of RAM (16GB is recommended but not always required). |
-| `dawarich_photon_version` | string | `latest` | ❌ | Photon Docker image version for reverse geocoding. |
-| `dawarich_photon_data_path` | path | `/opt/dawarich/photon` | ❌ | Photon data path on the host. |
-| `dawarich_photon_port` | int | `2322` | ❌ | Photon application port. |
-| `dawarich_photon_region` | string |  | ❌ | Photon reverse geocoding region. You can see available regions at <https://github.com/rtuszik/photon-docker/blob/main/README.md#available-regions>. |
-| `dawarich_photon_extra_env` | dict | `{}` | ❌ | Additional environment variables for the Photon container. |
-| `dawarich_prune_docker_images` | bool | `true` | ❌ | Prune *all* Docker images after deployment if any container has changed. |
+### Core Application Settings
+
+| Variable | Type | Default | Required |
+|----------|------|---------|----------|
+| `dawarich_data_path` | path | `/opt/dawarich` | ❌ |
+| `dawarich_docker_network_name` | string | `dawarich` | ❌ |
+| `dawarich_version` | string | `latest` | ❌ |
+| `dawarich_app_hosts` | string | None | ❌ |
+| `dawarich_app_protocol` | string | `http` | ❌ |
+| `dawarich_port` | int | `3000` | ❌ |
+| `dawarich_rails_env` | string | `development` | ❌ |
+| `dawarich_timezone` | string | `Etc/UTC` | ❌ |
+| `dawarich_encryption_secret_key` | string | None | ✅ |
+
+**Details:**
+- `dawarich_data_path`: Dawarich data path on the host.
+- `dawarich_docker_network_name`: Name of the Docker network to connect the Dawarich containers to.
+- `dawarich_version`: Dawarich application Docker image version (tag).
+- `dawarich_app_hosts`: Host of the Dawarich application (e.g. dawarich.example.com).
+- `dawarich_app_protocol`: Protocol for the Dawarich application. Set to `https` if accessing Dawarich through a SSL-terminating reverse proxy. Must be one of: `http`, `https`.
+- `dawarich_port`: Dawarich application port.
+- `dawarich_rails_env`: Rails environment for the Dawarich application. This should ideally be `production`, but some bugs have been observed in production mode that are not present in development mode.
+- `dawarich_timezone`: Timezone for the Dawarich application. See <https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#List>.
+- `dawarich_encryption_secret_key`: The Dawarich encryption salt/secret key (Rails' `secret_key_base`).
+
+> [!NOTE]
+> Regardless of the user-specified value for `dawarich_app_hosts`, `localhost,::1,127.0.0.1` will always be added to Dawarich's `APPLICATION_HOSTS`. Example: If you set the value as `dawarich.example.com`, it will be set to `dawarich.example.com,localhost,::1,127.0.0.1`. If left default (`None`), Dawarich's `APPLICATION_HOSTS` will be `localhost,::1,127.0.0.1`.
+
+### Processing Configuration
+
+| Variable | Type | Default | Required |
+|----------|------|---------|----------|
+| `dawarich_min_minutes_spent_in_city` | int | `60` | ❌ |
+| `dawarich_background_processing_concurrency` | int | `10` | ❌ |
+| `dawarich_workers_count` | int | `1` | ❌ |
+| `dawarich_store_geodata` | bool | `true` | ❌ |
+| `dawarich_rails_max_threads` | int | `dawarich_workers_count * dawarich_background_processing_concurrency` | ❌ |
+
+**Details:**
+- `dawarich_min_minutes_spent_in_city`: Minimum minutes spent in a city to be counted.
+- `dawarich_background_processing_concurrency`: Number of background processing workers per Sidekiq worker.
+- `dawarich_workers_count`: Number of Sidekiq workers to deploy.
+- `dawarich_store_geodata`: Enable storing of geodata in the Dawarich database.
+- `dawarich_rails_max_threads`: Connection pool size for the Dawarich database.
+
+> [!TIP]
+> The default value for `dawarich_rails_max_threads`, if undefined, is the number of workers multiplied by the background processing concurrency. For example, with 1 worker (default) and 10 background workers (default), this would be 10.
+
+### Reverse Geocoding
+
+| Variable | Type | Default | Required |
+|----------|------|---------|----------|
+| `dawarich_reverse_geocoding_enabled` | bool | `true` | ❌ |
+| `dawarich_photon_api_host` | string | `''` or `dawarich-photon` (see below) | ❌ |
+| `dawarich_photon_api_use_https` | bool | `true` | ❌ |
+
+**Details:**
+- `dawarich_reverse_geocoding_enabled`: Enable reverse geocoding.
+- `dawarich_photon_api_host`: API host for the Photon reverse geocoding service. If `dawarich_deploy_photon` is `false`, this will default to an empty string. Otherwise, if `dawarich_deploy_photon` is `true`, this will default to `dawarich-photon` (the name of the Photon container). You will only need to change this if you wish to use a different Photon instance, whether self-hosted or public.
+- `dawarich_photon_api_use_https`: Use HTTPS for requests to the Photon API.
+
+### PostGIS Database
+
+| Variable | Type | Default | Required |
+|----------|------|---------|----------|
+| `dawarich_deploy_postgis` | bool | `true` | ❌ |
+| `dawarich_postgis_version` | string | `17-3.5-alpine` | ❌ |
+| `dawarich_postgis_host` | string | `dawarich-db` | ❌ |
+| `dawarich_postgis_port` | int | `5432` | ❌ |
+| `dawarich_postgis_db_name` | string | `dawarich` | ❌ |
+| `dawarich_postgis_username` | string | `dawarich` | ❌ |
+| `dawarich_postgis_password` | string | None | ✅ |
+| `dawarich_postgis_use_custom_config` | bool | `false` | ❌ |
+| `dawarich_postgis_conf_file` | string |  | ❌ |
+
+**Details:**
+- `dawarich_deploy_postgis`: Deploy a PostGIS instance for Dawarich. Set to `false` if using an external PostGIS instance.
+- `dawarich_postgis_version`: PostGIS Docker image version for Dawarich.
+- `dawarich_postgis_host`: PostGIS host for Dawarich.
+- `dawarich_postgis_port`: PostGIS port for Dawarich.
+- `dawarich_postgis_db_name`: PostGIS database name for Dawarich.
+- `dawarich_postgis_username`: PostGIS username for Dawarich.
+- `dawarich_postgis_password`: PostGIS password for Dawarich.
+- `dawarich_postgis_use_custom_config`: Set to `true` if you want to use a custom config file.
+- `dawarich_postgis_conf_file`: Path to the PostgreSQL config file on the Ansible controller. If left default (empty) and `dawarich_postgis_use_custom_config` is `true`, the example config will be downloaded from the Dawarich repository at <https://github.com/Freika/dawarich/blob/master/postgisql.conf.example>.
+
+> [!NOTE]
+> `dawarich_postgis_conf_file` is ignored unless `dawarich_postgis_use_custom_config` is `true`.
+
+### Redis
+
+| Variable | Type | Default | Required |
+|----------|------|---------|----------|
+| `dawarich_deploy_redis` | bool | `true` | ❌ |
+| `dawarich_redis_version` | string | `7.4-alpine` | ❌ |
+| `dawarich_redis_host` | string | `dawarich-redis` | ❌ |
+| `dawarich_redis_port` | int | `6379` | ❌ |
+
+**Details:**
+- `dawarich_deploy_redis`: Deploy a Redis instance for Dawarich. Set to `false` if using an external Redis instance.
+- `dawarich_redis_version`: Redis Docker image version for Dawarich.
+- `dawarich_redis_host`: Redis host for Dawarich.
+- `dawarich_redis_port`: Redis port for Dawarich.
+
+### Photon (Self-hosted Reverse Geocoding)
+
+| Variable | Type | Default | Required |
+|----------|------|---------|----------|
+| `dawarich_deploy_photon` | bool | `false` | ❌ |
+| `dawarich_photon_version` | string | `latest` | ❌ |
+| `dawarich_photon_data_path` | path | `/opt/dawarich/photon` | ❌ |
+| `dawarich_photon_port` | int | `2322` | ❌ |
+| `dawarich_photon_region` | string |  | ❌ |
+| `dawarich_photon_extra_env` | dict | `{}` | ❌ |
+
+**Details:**
+- `dawarich_deploy_photon`: Deploy a Photon instance for reverse geocoding.
+- `dawarich_photon_version`: Photon Docker image version for reverse geocoding.
+- `dawarich_photon_data_path`: Photon data path on the host.
+- `dawarich_photon_port`: Photon application port.
+- `dawarich_photon_region`: Photon reverse geocoding region. You can see available regions at <https://github.com/rtuszik/photon-docker/blob/main/README.md#available-regions>.
+- `dawarich_photon_extra_env`: Additional environment variables for the Photon container.
+
+> [!WARNING]
+> Photon requires well over 120GB of disk space and a significant amount of RAM (16GB is recommended but not always required), assuming you are not specifying `dawarich_photon_region` to limit the downloaded dataset to a single region.
+
+### Monitoring & Resource Limits
+
+| Variable | Type | Default | Required |
+|----------|------|---------|----------|
+| `dawarich_enable_prometheus_metrics` | bool | `false` | ❌ |
+| `dawarich_prometheus_port` | int | `9394` | ❌ |
+| `dawarich_log_max_size` | string | `100m` | ❌ |
+| `dawarich_log_max_file` | int | `5` | ❌ |
+| `dawarich_app_cpu_limit` | string | `0.50` | ❌ |
+| `dawarich_app_memory_limit` | string | `4G` | ❌ |
+| `dawarich_sidekiq_cpu_limit` | string | `0.50` | ❌ |
+| `dawarich_sidekiq_memory_limit` | string | `4G` | ❌ |
+
+**Details:**
+- `dawarich_enable_prometheus_metrics`: Enable Prometheus metrics endpoint. Once enabled, Prometheus metrics will be available at `localhost:<dawarich_prometheus_port>/metrics`.
+- `dawarich_prometheus_port`: Prometheus metrics port for Dawarich.
+- `dawarich_log_max_size`: Maximum size of Docker log files before rotation.
+- `dawarich_log_max_file`: Maximum number of Docker log files to keep.
+- `dawarich_app_cpu_limit`: CPU limit for the Dawarich application container (e.g., `0.50` for 50% of one core). Set to `0` to disable CPU limit.
+- `dawarich_app_memory_limit`: Memory limit for the Dawarich application container. Set to `0` to disable memory limit.
+- `dawarich_sidekiq_cpu_limit`: CPU limit for each Dawarich Sidekiq worker container (e.g., `0.50` for 50% of one core). Set to `0` to disable CPU limit.
+- `dawarich_sidekiq_memory_limit`: Memory limit for each Dawarich Sidekiq worker container. Set to `0` to disable memory limit.
+
+### Extra Environment Variables
+
+| Variable | Type | Default | Required |
+|----------|------|---------|----------|
+| `dawarich_shared_extra_env` | dict | `{}` | ❌ |
+| `dawarich_app_extra_env` | dict | `{}` | ❌ |
+| `dawarich_sidekiq_extra_env` | dict | `{}` | ❌ |
+
+**Details:**
+- `dawarich_shared_extra_env`: Additional environment variables to apply to both the Dawarich application and the Sidekiq worker(s) containers.
+- `dawarich_app_extra_env`: Additional environment variables for the Dawarich application container.
+- `dawarich_sidekiq_extra_env`: Additional environment variables for the Dawarich Sidekiq worker container(s).
+
+### Docker Image Management
+
+| Variable | Type | Default | Required |
+|----------|------|---------|----------|
+| `dawarich_prune_docker_images` | bool | `true` | ❌ |
+
+**Details:**
+- `dawarich_prune_docker_images`: Prune *all* Docker images after deployment if any container has changed.
 
 <!-- END ANSIBLE ROLE VARIABLES -->
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ See [Example Playbooks](#example-playbooks) below.
 > [!NOTE]
 > Regardless of the user-specified value for `dawarich_app_hosts`, `localhost,::1,127.0.0.1` will always be added to Dawarich's `APPLICATION_HOSTS`. Example: If you set the value as `dawarich.example.com`, it will be set to `dawarich.example.com,localhost,::1,127.0.0.1`. If left default (`None`), Dawarich's `APPLICATION_HOSTS` will be `localhost,::1,127.0.0.1`.
 
+### Authentication & OIDC
+
+Dawarich supports OpenID Connect (OIDC) authentication, allowing you to integrate with identity providers like Authentik, Keycloak, Auth0, and others. When configured, users can log in using your OIDC provider instead of (or in addition to) email/password authentication.
+
+To enable OIDC, you'll need to configure your identity provider and then pass the required environment variables to Dawarich using `dawarich_app_extra_env` or `dawarich_shared_extra_env`.
+
+**Required OIDC environment variables:**
+- `OIDC_CLIENT_ID`: Your OIDC client ID
+- `OIDC_CLIENT_SECRET`: Your OIDC client secret
+- `OIDC_ISSUER`: Your OIDC issuer URL (e.g., `https://authentik.yourdomain.com/application/o/dawarich/`)
+- `OIDC_REDIRECT_URI`: The callback URL for your Dawarich instance (e.g., `https://dawarich.example.com/users/auth/openid_connect/callback`)
+
+**Optional OIDC environment variables:**
+- `OIDC_AUTO_REGISTER`: Automatically register new users on first OIDC login (default: `false`)
+- `OIDC_PROVIDER_NAME`: Custom name for your provider displayed on the login page (default: `OpenID Connect`)
+- `ALLOW_EMAIL_PASSWORD_REGISTRATION`: Allow email/password registration alongside OIDC (default: `true`)
+
 ### Processing Configuration
 
 | Variable | Type | Default | Required |
@@ -231,6 +248,27 @@ See [Example Playbooks](#example-playbooks) below.
 > Photon requires well over 120GB of disk space and a significant amount of RAM (16GB is recommended but not always required).
 > 
 > Refer to [`dawarich_photon_region`](#dawarich_photon_region) to restrict the downloaded dataset to a single region to significantly reduce these requirements.
+
+**With OIDC authentication:**
+
+```yml
+---
+- name: Deploy Dawarich
+  hosts: server
+  roles:
+    - role: tigattack.dawarich
+      vars:
+        dawarich_postgis_password: _!CHANGEME!_
+        dawarich_encryption_secret_key: _!CHANGEME!_
+        dawarich_app_hosts: dawarich.example.com
+        dawarich_app_protocol: https
+        dawarich_app_extra_env:
+          OIDC_CLIENT_ID: your_client_id
+          OIDC_CLIENT_SECRET: your_client_secret
+          OIDC_ISSUER: https://auth.example.com/application/o/dawarich/
+          OIDC_REDIRECT_URI: https://dawarich.example.com/users/auth/openid_connect/callback
+          OIDC_PROVIDER_NAME: Authentik
+```
 
 ## License
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -103,9 +103,7 @@ dawarich_worker_container:
   interactive: true
   tty: true
   healthcheck:
-    test:
-      - "CMD-SHELL"
-      - "pgrep -f sidekiq"
+    test: ["CMD-SHELL", "pgrep -f sidekiq"]
     interval: 10s
     retries: 30
     start_period: 30s
@@ -126,7 +124,7 @@ dawarich_worker_container:
     max-file: "{{ dawarich_log_max_file | string }}"
   cpus: "{{ dawarich_sidekiq_cpu_limit }}"
   memory: "{{ dawarich_sidekiq_memory_limit }}"
-  state: healthy
+  state: started
 
 dawarich_workers: |
   {%- set workers = [] %}


### PR DESCRIPTION
Changes overall:

Health check would hang and timeout on deployment despite Sidekiq being fine. It does show (unhealthy) sometimes but the container itself is processing so I changed the check:

1. The health check was a nested array and not flat as `community.docker.docker_container` expects. This meant the custom healthcheck wasn't overriding the image's `bundle exec sidekiqmon processes | grep ${HOSTNAME}` which apparently isn't very good anyway.

2. Changed from `state: healthy` to `state: started`. IMO for background workers this shouldn't matter, they shouldn't 'health-gate' a deployment. 

General README changes:

1. Made it much more readable (imo). There was too little screen real estate being used to display the information. I did try and make this into a fuckoff table which was good in preview but when pushed to gh I remembered the sizing is static, so ended up with this version. 
Feel free to decline this, I personally think it is better but if you disagree then all good. 

2. As part of the above, added OIDC info. 

Cheers, hmu if any issues.